### PR TITLE
Make uploading coverage data to coveralls a separate step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '0.10'
+after_success: npm run report-coverage
 deploy:
   provider: npm
   email: d2ltravisdeploy@d2l.com

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Utility for publishing free-range apps to our CDN.",
   "main": "publisher.js",
   "scripts": {
-    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec",
+    "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We really only want to report coverage when the tests fail.  Also, this
allows npm test to report coverage on the command line :).
