### PR TITLE
Adding pretty coverage reports to npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utility for publishing free-range apps to our CDN.",
   "main": "publisher.js",
   "scripts": {
-    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec",
+    "test": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec",
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "repository": {


### PR DESCRIPTION
We were previously only using coverage for Coveralls, but that seems silly
now :).
