### PR TITLE
Catching errors from the CLI and exiting with 1

### DIFF
--- a/bin/publishercli
+++ b/bin/publishercli
@@ -45,8 +45,12 @@ if (opts.moduleType === 'app') {
 
 vfs.src(opts.files).pipe(
 	publisher.getStream()
-).on('end', function() {
+).on('error', function(err) {
+	console.log(chalk.red('Error occurred during publishing', err));
+	process.exit(1);
+}).on('end', function() {
 	console.log(chalk.green('Published to:\n\n') + chalk.grey(
 		'   ' + publisher.getLocation() + '\n'
 	));
+	process.exit(0);
 });

--- a/bin/publishercli
+++ b/bin/publishercli
@@ -30,7 +30,7 @@ console.log(chalk.green('Publish options:\n\n') + chalk.grey(
 		'   Target directory: ' + opts.targetDirectory + '\n' +
 		'   Module type: ' + opts.moduleType + '\n' +
 		'   Files: ' + opts.files + '\n' +
-		'   Publish key: ' + opts.creds.key + '\n' + 
+		'   Publish key: ' + opts.creds.key + '\n' +
 		'   Publish secret: ' + (opts.creds.secret ? '[secret]' : 'undefined') + '\n' +
 		'   Dev tag: ' + opts.devTag + '\n' +
 		'   Version: ' + opts.version + '\n'
@@ -52,5 +52,4 @@ vfs.src(opts.files).pipe(
 	console.log(chalk.green('Published to:\n\n') + chalk.grey(
 		'   ' + publisher.getLocation() + '\n'
 	));
-	process.exit(0);
 });

--- a/src/overwrite.js
+++ b/src/overwrite.js
@@ -2,7 +2,6 @@
 
 var es = require('event-stream'),
 	knox = require('knox'),
-	gutil = require('gulp-util'),
 	Q = require('q');
 
 module.exports = function(options) {
@@ -48,7 +47,6 @@ function checkFilesExist(options) {
 		if (data.Contents.length !== 0) {
 			// files exist in s3 folder
 			var errorMsg = 'No files transferred because files already exists in ' + options.getUploadPath();
-			gutil.log(gutil.colors.red(errorMsg));
 			deferred.reject(new Error(errorMsg));
 			return;
 		}


### PR DESCRIPTION
This is so that consumers will actually fail with an exit code of `1` when a publish fails because files already exist. We had a situation today where a publish didn't happen because files were already there but the CI run passed so nobody knew.