### PR TITLE
Fix Windows path regex to find and replace backslashes

### DIFF
--- a/src/s3.js
+++ b/src/s3.js
@@ -5,7 +5,7 @@ const knox = require('knox');
 const mime = require('mime-types');
 const promised = require('promised-method');
 
-const WINDOWS_SLASH_REGEX = /\//g;
+const WINDOWS_SLASH_REGEX = /\\/g;
 function replaceWindowsSlash(path) {
 	return path.replace(WINDOWS_SLASH_REGEX, '/');
 }


### PR DESCRIPTION
I ran into some issues today publishing a package to the CDN from a Windows machine, and I think this replaceWindowsSlash function is the culprit. Specifically, I believe the regex used to find the backslashes needs to be tweaked.

I did poke around locally to make sure this produced uploadPaths that one would expect, and it looks like it accomplishes that goal.