### PR TITLE
Add xml to compression list

### DIFF
--- a/src/compressor.js
+++ b/src/compressor.js
@@ -10,6 +10,7 @@ const compressibles = [
 	'.json',
 	'.css',
 	'.html',
+	'.xml',
 	'.svg',
 	'.ttf',
 	'.ico'


### PR DESCRIPTION
This PR adds the xml extension to the compression list. This will allow the LMS language files to be served with gzip from the cloud front.