### PR TITLE
allow version as CLI parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ This repository is configured with [EditorConfig](http://editorconfig.org) rules
 
 [npm-url]: https://npmjs.org/package/frau-publisher
 [npm-image]: https://img.shields.io/npm/v/frau-publisher.svg
-[ci-image]: https://travis-ci.org/Brightspace/frau-publisher.svg?branch=master
-[ci-url]: https://travis-ci.org/Brightspace/frau-publisher
+[ci-image]: https://api.travis-ci.com/Brightspace/frau-publisher.svg?branch=master
+[ci-url]: https://travis-ci.com/Brightspace/frau-publisher
 [coverage-image]: https://img.shields.io/coveralls/Brightspace/frau-publisher.svg
 [coverage-url]: https://coveralls.io/r/Brightspace/frau-publisher?branch=master
 [dependencies-url]: https://david-dm.org/brightspace/frau-publisher

--- a/bin/publishercli
+++ b/bin/publishercli
@@ -10,6 +10,7 @@ const vfs = require('vinyl-fs');
 const optionsProvider = require('../src/optionsProvider');
 
 const argv = yargs
+	.version(false)
 	.alias('m', 'moduletype')
 	.alias('t', 'targetdir')
 	.alias('f', 'files')


### PR DESCRIPTION
Apparently as of `yargs` version 9, you can't use "version" as a parameter into your application since `--version` and `--help` are built-in things that it natively handles "for you". But `--version` is a parameter `frau-publisher` uses to pass in the version of the app/lib you'd like to publish.

I'm guessing we don't typically use the CLI arguments but instead prefer the configs inside the `package.json` files.