### PR TITLE
Revert "Conditionally append `appconfig.json` if `app`"

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -85,8 +85,7 @@ function helper(opts, initialPath) {
 		},
 		getLocation: function() {
 			const options = optionsValidator(opts);
-			const appendAppconfigJson = opts.moduleType === 'app' ? 'appconfig.json' : '';
-			return 'https://s.brightspace.com/' + options.getUploadPath() + '/' + appendAppconfigJson;
+			return 'https://s.brightspace.com/' + options.getUploadPath() + '/';
 		}
 	};
 }


### PR DESCRIPTION
This reverts commit b68fc2da11f93bd0c4d3cf425683e8e02d78e8ad (https://github.com/Brightspace/frau-publisher/pull/190). This was just released today even though it was merged back in 2021, and is causing BSI to not upload any files (and not throw any errors).

Priority is to get a new version released to fix BSI and any FRAs that don't lock their `frau-publisher` version. We can look at whether we still want this change in afterwards. I'm _assuming_ it's not urgent if it was never released.