### PR TITLE
fix: try reverting dependency bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "pump": "^3",
     "semver": "^7",
     "through2-concurrent": "^2",
-    "vinyl": "^3.0.0",
+    "vinyl": "^2",
     "vinyl-fs": "^3",
-    "yargs": "^17"
+    "yargs": "^16"
   }
 }


### PR DESCRIPTION
Doesn't seem like the code revert fixed it: https://github.com/Brightspace/brightspace-integration/actions/runs/7505050243/job/20433615596#step:13:49

Trying to non-dev dependency bumps next.