### PR TITLE
GAUD-6046 - Use new CDN role from repo-settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          role-to-assume: "arn:aws:iam::771734770799:role/cdn-infrastructure-frau-publisher-test"
+          role-to-assume: "arn:aws:iam::771734770799:role/r+Brightspace+frau-publisher+repo"
           role-duration-seconds: 3600
           aws-region: us-east-1
       - name: Publish Tests


### PR DESCRIPTION

This PR assumes the new hub role from repo-settings, set up in https://github.com/Brightspace/repo-settings/pull/1681. CI will fail until it exists, I'll re-run when it does.