### PR TITLE
GAUD-9964: add through2 to Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       # is esm-only
       - dependency-name: chalk
         versions: '>= 5'
+      # is esm-only
+      - dependency-name: through2
+        versions: '>= 5'
     cooldown:
       # update-package-lock workflow handles minor/patch updates - delay for a few weeks to give time to handle breaking change in those PRs
       default-days: 25


### PR DESCRIPTION
We can't upgrade to v5 of `through2` as it's ESM-only. This prevents Dependabot from [trying to upgrade it](https://github.com/Brightspace/frau-publisher/pull/260).